### PR TITLE
chore: update github actions workflows

### DIFF
--- a/.github/workflows/profile-summary-cards.yml
+++ b/.github/workflows/profile-summary-cards.yml
@@ -1,8 +1,6 @@
 name: GitHub-Profile-Summary-Cards
 
 on:
-  create:
-  push:
   schedule: # execute every 24 hours
     - cron: "* */24 * * *"
   workflow_dispatch:
@@ -10,12 +8,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: generate
+    name: generate-github-profile-summary-cards
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: vn7n24fzkq/github-profile-summary-cards@release
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+        env: # default use ${{ secrets.SUMMARY_GITHUB_TOKEN }}, you should replace with your personal access token
+          GITHUB_TOKEN: ${{ secrets.SUMMARY_GITHUB_TOKEN }}
         with:
           USERNAME: ${{ github.repository_owner }}
+          # BRANCH_NAME is optional, default to main, branch name to push cards
+          BRANCH_NAME: "main"
+          # UTC_OFFSET is optional, default to zero
+          UTC_OFFSET: 8
+          # EXCLUDE is an optional comma seperated list of languages to exclude, defaults to ""
+          EXCLUDE: ""
+          # AUTO_PUSH is optional, a boolean variable default to true, whether automatically push generated files to desired branch
+          AUTO_PUSH: true

--- a/.github/workflows/terminal-gif.yml
+++ b/.github/workflows/terminal-gif.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
-    - uses: dgokcin/github-profile-terminal-action@main
+    - uses: actions/checkout@v4
+    - uses: liamg/github-profile-terminal-action@main
       with:
         theme: dark
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- remove create and push triggers from profile-summary-cards workflow
- update cron schedule to execute every 24 hours
- rename job name to generate-github-profile-summary-cards
- add permissions to write contents
- update actions/checkout to v4
- update environment variables and add optional parameters
- update terminal-gif workflow to use actions/checkout@v4
- change terminal action to liamg/github-profile-terminal-action@main
